### PR TITLE
Add X-Clacks Overhead memorials http head/meta tags

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -2,6 +2,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner" /> 
+  <meta http-equiv="X-Clacks-Overhead" content="GNU Russel Winder" /> 
 
   <title>{% if page.title %}{{ page.title }} &ndash; {% endif %}{{ site.title }}</title>
 


### PR DESCRIPTION
Although it's kinda too late for this year, I figured I'd add this as a base for future year's copypasting

this html `<meta>` tag is the [recommended way](http://www.gnuterrypratchett.com/#HTML) to implement gnu-terry-pratchett if you don't have control over your webserver's headers.

looks like we're currently hosted by netlify so [there may be another way](https://docs.netlify.com/routing/headers/) -- but that would lock us into netlify a bit?  this felt more vendor-neutral.  not that bothered tho.  more keen on making the gesture one way or another.